### PR TITLE
actions: Implement post-processor functionality

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -71,7 +71,7 @@ entry actually appears in Elasticsearch.  By default this is every 30 seconds.
     usage
     configuration
     advanced_usage
+    postprocessors
     api
     backend
     developers
-

--- a/docs/postprocessors.rst
+++ b/docs/postprocessors.rst
@@ -1,0 +1,69 @@
+Post-processors
+===============
+
+Post-processors are arbitrary functions which are applied to log entries
+directly before they go into Elasticsearch.  They can be specified easily in the
+call to ``logging.Logger.log()`` and family::
+
+    from logging import getLogger
+    my_logger = getLogger(__name__)
+    # Assume we set up Lumberjack and attach it somewhere in the heirarchy of
+    # this logger.
+
+    my_logger.info({'a': 'message'}, {'postprocessors': [some_postprocessor]})
+
+In this example, the post-processor ``some_postprocessor`` will be applied to
+the logged document immediately before sending to Elasticsearch.
+
+A post-processor is simply a function which is passed the document, and should
+return a modified version of it.  For example, a postprocessor might add the
+hostname of the machine currently running the program::
+
+    import socket
+    def hostname(doc):
+        doc['hostname'] = socket.gethostname()
+
+    my_logger.info({'a': 'message'}, {'postprocessors': [hostname]})
+
+On a system with hostname ``load-balancer-01``, this would result in the
+following document being sent to Elasticsearch::
+
+    {
+        'a': 'message',
+        '@timestamp': 1438353254000, # Timestamp added automatically
+        'level': 20, # Log level (logging.INFO) added automatically
+        'hostname': 'load-balancer-01'
+    }
+
+Included post-processors
+------------------------
+
+Lumberjack provides some postprocessors out-of-the-box for you to use, which you
+can find in ``lumberjack.postprocessors``.
+
+GeoIP
++++++
+
+This post-processor will perform a GeoIP lookup on a field containing an IP
+address, and include the results in the document::
+
+    from lumberjack.postprocessors import geoip
+    my_geoip = geoip(field='ip')
+
+    my_logger.info({
+        'a': 'message',
+        'ip': '128.141.43.1'
+    }, {'postprocessors': [my_geoip]})
+
+This will result in the following document being sent to Elasticsearch::
+
+    {
+        'a': 'message',
+        '@timestamp': 1438353254000, # Timestamp added automatically
+        'level': 20, # Log level (logging.INFO) added automatically
+        'ip': '128.141.43.1',
+        'geoip': {
+            'country_code': 'CH',
+            'location': {'lat': 46.1956, 'lon': 6.1481}
+        }
+    }

--- a/lumberjack/handler.py
+++ b/lumberjack/handler.py
@@ -92,5 +92,9 @@ class ElasticsearchHandler(logging.Handler):
         suffix = time.strftime(self.suffix_format, time.gmtime(record.created))
         (es_type, document) = self.format(record)
 
+        postprocessors = record.args['postprocessors'] \
+            if 'postprocessors' in record.args else None
+
         self.action_queue.queue_index(suffix=suffix, doc_type=es_type,
-                                      body=document)
+                                      body=document,
+                                      postprocessors=postprocessors)

--- a/lumberjack/postprocessors/__init__.py
+++ b/lumberjack/postprocessors/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Lumberjack.
-# Copyright 2014 CERN.
+# Copyright 2015 CERN.
 #
 # Lumberjack is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -16,9 +16,10 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Lumberjack.  If not, see <http://www.gnu.org/licenses/>.
 
+"""Helper postprocessors for plugging into Lumberjack."""
+
 from __future__ import absolute_import
 
-from .log import *
-from .schema import *
-from .actions import *
-from .postprocessors import *
+from .geoip import geoip
+
+__all__ = ('geoip')

--- a/lumberjack/postprocessors/geoip.py
+++ b/lumberjack/postprocessors/geoip.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Lumberjack.
-# Copyright 2014 CERN.
+# Copyright 2015 CERN.
 #
 # Lumberjack is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -16,9 +16,26 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Lumberjack.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import absolute_import
+"""Postprocessor to provide GeoIP lookup."""
 
-from .log import *
-from .schema import *
-from .actions import *
-from .postprocessors import *
+from __future__ import absolute_import
+from geoip import geolite2
+
+
+def geoip(field='ip'):
+    """Postprocessor to collect GeoIP data from an IP field in the log entry.
+
+    :param field: The name of the field which contains the IP.
+    """
+    def _inner(doc):
+        ip_data = geolite2.lookup(doc[field])
+        if ip_data is not None:
+            doc['geoip'] = {
+                'country_code': ip_data.country,
+                'location': {
+                    'lat': ip_data.location[0],
+                    'lon': ip_data.location[1]
+                }
+            }
+        return doc
+    return _inner

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,8 @@ setup(
     platforms='any',
     install_requires=[
         'elasticsearch',
+        'python-geoip',
+        'python-geoip-geolite2',
     ],
     extras_require={
         "docs": "sphinx"

--- a/tests/common.py
+++ b/tests/common.py
@@ -23,6 +23,7 @@ import lumberjack
 from random import randint
 from elasticsearch import NotFoundError
 import time
+from mock import MagicMock
 
 HOSTS = [{'host': 'localhost', 'port': 9199}]
 INDEX_PREFIX = 'test-lumberjack-'
@@ -128,8 +129,6 @@ class TestHandler(logging.Handler):
                     repr(record.exc_info[1]) + ' != ' + repr(exception))
 
 def patchLumberjackObject(lj):
-    def noop(*args, **kwargs):
-        pass
-    lj.action_queue.bulk = noop
-    lj.elasticsearch.indices.put_mapping = noop
-    lj.elasticsearch.indices.put_template = noop
+    lj.action_queue._bulk = MagicMock()
+    lj.elasticsearch.indices.put_mapping = MagicMock()
+    lj.elasticsearch.indices.put_template = MagicMock()

--- a/tests/postprocessors.py
+++ b/tests/postprocessors.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Lumberjack.
+# Copyright 2015 CERN.
+#
+# Lumberjack is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# Lumberjack is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Lumberjack.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+import logging
+from mock import MagicMock
+
+import lumberjack
+
+from .common import LumberjackTestCase, skipIfNotMock, TestHandler
+
+LOGGER_NAME = 'test'
+
+
+class MyException(Exception):
+    pass
+
+
+class PostprocessorsTestCase(LumberjackTestCase):
+    def setUp(self):
+        super(PostprocessorsTestCase, self).setUp()
+        self.getLumberjackObject()
+
+        self.logger = logging.getLogger(LOGGER_NAME)
+
+        self.handler = self.lj.get_handler()
+        self.logger.addHandler(self.handler)
+
+    def tearDown(self):
+        self.logger.handlers = []
+        super(PostprocessorsTestCase, self).tearDown()
+
+    def _disable_action_queue(self):
+        """Stop the queue now so we don't call things twice accidentally"""
+        self.lj.action_queue.running = False
+        self.lj.action_queue.trigger_flush()
+        self.lj.action_queue.join()
+
+    def _check_source_in_queue(self, source):
+        # We only ever call bulk with 2 positional arguments, so if this raises
+        # a KeyError, we have bigger problems
+        called_queue = self.lj.action_queue._bulk.call_args[0][1]
+        self.assertEqual(len(called_queue), 1)
+
+        queue_source = called_queue[0]['_source']
+        for k, v in source.items():
+            self.assertIn(k, queue_source)
+            self.assertEqual(v, queue_source[k])
+
+    @skipIfNotMock
+    def test_postprocessors(self):
+        self._disable_action_queue()
+
+        postprocessor_return = {'a': 1, 'b': 2}
+        postprocessor = MagicMock(return_value=postprocessor_return)
+
+        data = {'a': 1}
+        self.logger.info(data, {'postprocessors': [postprocessor]})
+        self.lj.action_queue._flush()
+
+        try:
+            called_msg = postprocessor.call_args[0][0]
+        except KeyError:
+            self.fail('Postprocessor not called with right parameter: ' +
+                repr(called_msg))
+        except TypeError:
+            self.fail('Postprocessor not called')
+        else:
+            for k, v in data.items():
+                self.assertIn(k, called_msg)
+                self.assertEqual(v, called_msg[k])
+
+        self._check_source_in_queue(postprocessor_return)
+
+    @skipIfNotMock
+    def test_postprocessors_error(self):
+        self._disable_action_queue()
+        self.lj.action_queue._bulk = MagicMock()
+
+        my_handler = TestHandler()
+        logging.getLogger('lumberjack.actions').addHandler(my_handler)
+
+        my_exception = MyException('This exception should be handled')
+        postprocessor = MagicMock(
+            side_effect=my_exception)
+
+        data = {'a': 1}
+        self.logger.info(data, {'postprocessors': [postprocessor]})
+        try:
+            self.lj.action_queue._flush()
+        except MyException:
+            self.fail('Uncaught exception in a postprocessor')
+        finally:
+            my_handler.assertLoggedWithException('lumberjack.actions', 'ERROR',
+                'Postprocessor ' + repr(postprocessor) +
+                ' raised an exception.', my_exception)
+
+        self._check_source_in_queue(data)
+
+    @skipIfNotMock
+    def test_postprocessors_error_after_dict_mutation(self):
+        def my_postprocessor(doc):
+            doc['canary'] = 'shouldn\'t be here'
+            raise MyException('This exception should be handled and logged')
+
+        data = {'a': 1}
+        self.logger.info(data, {'postprocessors': [my_postprocessor]})
+        self.lj.action_queue._flush()
+
+        queue_source = self.lj.action_queue._bulk.call_args[0][1][0]['_source']
+        self.assertNotIn('canary', queue_source)
+
+    @skipIfNotMock
+    def test_geoip(self):
+        from lumberjack.postprocessors import geoip
+        from geoip import geolite2
+
+        self._disable_action_queue()
+        self.lj.action_queue._bulk = MagicMock()
+
+        ip = '128.141.43.1'
+        ip_lookup_data = geolite2.lookup(ip)
+        geopoint = {
+            'lat': ip_lookup_data.location[0],
+            'lon': ip_lookup_data.location[1]
+        }
+
+        self.logger.info({'ip': ip},
+            {'postprocessors': [geoip(field='ip')]})
+        self.lj.action_queue._flush()
+
+        self._check_source_in_queue({
+            'ip': ip,
+            'geoip': {
+                'country_code': ip_lookup_data.country,
+                'location': geopoint
+            }
+        })


### PR DESCRIPTION
- Post-processors can be specified at the time of logging, and will be run in
  the action thread immediately before indexing.
- Includes a GeoIP post-processor which works out of the box

Signed-off-by: Joe MacMahon joe.macmahon@cern.ch
